### PR TITLE
squashfs*-tools: add patches addressing gcc10 -fno-common

### DIFF
--- a/tools/make/squashfs2-host/patches/910-gcc10_fix_multiple_definitions_error.patch
+++ b/tools/make/squashfs2-host/patches/910-gcc10_fix_multiple_definitions_error.patch
@@ -1,0 +1,11 @@
+--- squashfs-tools/read_fs.c
++++ squashfs-tools/read_fs.c
+@@ -62,7 +62,7 @@ extern int add_file(int, int, unsigned i
+ 
+ #define ERROR(s, args...)		fprintf(stderr, s, ## args)
+ 
+-int swap;
++extern int swap;
+ 
+ int read_block(int fd, int start, int *next, unsigned char *block, squashfs_super_block *sBlk)
+ {

--- a/tools/make/squashfs3-host/patches/910-gcc10_fix_multiple_definitions_error.patch
+++ b/tools/make/squashfs3-host/patches/910-gcc10_fix_multiple_definitions_error.patch
@@ -1,0 +1,11 @@
+--- squashfs-tools/read_fs.c
++++ squashfs-tools/read_fs.c
+@@ -73,7 +73,7 @@ extern zlib_uncompress_t uncompress_fct;
+ #define uncompress_fct uncompress
+ #endif
+ 
+-int swap;
++extern int swap;
+ 
+ int read_block(int fd, long long start, long long *next, unsigned char *block, squashfs_super_block *sBlk)
+ {

--- a/tools/make/squashfs4-host-be/patches/910-gcc10_fix_multiple_definitions_error.patch
+++ b/tools/make/squashfs4-host-be/patches/910-gcc10_fix_multiple_definitions_error.patch
@@ -1,0 +1,11 @@
+--- squashfs-tools/mksquashfs.h
++++ squashfs-tools/mksquashfs.h
+@@ -132,7 +132,7 @@ struct append_file {
+ #define BLOCK_OFFSET 2
+ 
+ extern struct cache *reader_buffer, *fragment_buffer, *reserve_cache;
+-struct cache *bwriter_buffer, *fwriter_buffer;
++extern struct cache *bwriter_buffer, *fwriter_buffer;
+ extern struct queue *to_reader, *to_deflate, *to_writer, *from_writer,
+ 	*to_frag, *locked_fragment, *to_process_frag;
+ extern struct append_file **file_mapping;


### PR DESCRIPTION
gcc-10 and above flipped a default from -fcommon to -fno-common. For details see [https://wiki.gentoo.org/wiki/Gcc_10_porting_notes/fno_common](https://wiki.gentoo.org/wiki/Gcc_10_porting_notes/fno_common). These patches are following the prefered method to fix the problem.